### PR TITLE
Fix "Internal Server Error" when no pronunciation is found, fix missing translation

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -130,7 +130,7 @@ export const parsePage = async (
 		);
 
 		// get pronunciation
-		pronunciation += await page.evaluate(() => document.querySelector<HTMLElement>('div[data-location="2"] > div')?.innerText?.replace(/[\u200B-\u200D\uFEFF]/g, ""));
+		pronunciation += await page.evaluate(() => document.querySelector<HTMLElement>('div[data-location="2"] > div')?.innerText?.replace(/[\u200B-\u200D\uFEFF]/g, "")) || "";
 
 		// get next page
 		const shouldContinue = await page.evaluate(() => {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -117,7 +117,7 @@ export const parsePage = async (
 	let pronunciation = "";
 	do {
 		// const targetSelector = `span[data-language-for-alternatives=${to}]`;
-		const targetSelector = `.ryNqvb`;
+		const targetSelector = `span[lang=${to}] > span > span`;
 		await page.waitForSelector(targetSelector);
 
 		// get translated text

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -130,9 +130,7 @@ export const parsePage = async (
 		);
 
 		// get pronunciation
-		pronunciation += await page.evaluate(
-			() => document.querySelector<HTMLElement>('div[data-location="2"] > div')?.innerText?.replace(/[\u200B-\u200D\uFEFF]/g, "") || null
-		);
+		pronunciation += await page.evaluate(() => document.querySelector<HTMLElement>('div[data-location="2"] > div')?.innerText?.replace(/[\u200B-\u200D\uFEFF]/g, ""));
 
 		// get next page
 		const shouldContinue = await page.evaluate(() => {
@@ -214,9 +212,7 @@ export const parsePage = async (
 			  });
 
 	// get from pronunciation
-	const fromPronunciation = await page.evaluate(
-		() => document.querySelector<HTMLElement>('div[data-location="1"] > div')?.innerText?.replace(/[\u200B-\u200D\uFEFF]/g, "") || null
-	);
+	const fromPronunciation = await page.evaluate(() => document.querySelector<HTMLElement>('div[data-location="1"] > div')?.innerText?.replace(/[\u200B-\u200D\uFEFF]/g, "")) || undefined;
 
 	const noDetails = await page.evaluate(() => {
 		return document
@@ -418,7 +414,7 @@ export const parsePage = async (
 		fromDidYouMean,
 		fromSuggestions,
 		fromPronunciation,
-		pronunciation,
+		pronunciation: pronunciation || undefined,
 		examples,
 		definitions,
 		translations,

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -117,7 +117,7 @@ export const parsePage = async (
 	let pronunciation = "";
 	do {
 		// const targetSelector = `span[data-language-for-alternatives=${to}]`;
-		const targetSelector = `span[lang=${to}]`;
+		const targetSelector = `.ryNqvb`;
 		await page.waitForSelector(targetSelector);
 
 		// get translated text
@@ -131,10 +131,7 @@ export const parsePage = async (
 
 		// get pronunciation
 		pronunciation += await page.evaluate(
-			() =>
-				document
-					.querySelector<HTMLElement>('div[data-location="2"] > div')!
-					.innerText!.replace(/[\u200B-\u200D\uFEFF]/g, "") || undefined
+			() => document.querySelector<HTMLElement>('div[data-location="2"] > div')?.innerText?.replace(/[\u200B-\u200D\uFEFF]/g, "") || null
 		);
 
 		// get next page
@@ -218,10 +215,7 @@ export const parsePage = async (
 
 	// get from pronunciation
 	const fromPronunciation = await page.evaluate(
-		() =>
-			document
-				.querySelector<HTMLElement>('div[data-location="1"] > div')!
-				.innerText!.replace(/[\u200B-\u200D\uFEFF]/g, "") || undefined
+		() => document.querySelector<HTMLElement>('div[data-location="1"] > div')?.innerText?.replace(/[\u200B-\u200D\uFEFF]/g, "") || null
 	);
 
 	const noDetails = await page.evaluate(() => {


### PR DESCRIPTION
The API route fails when it can't find a pronunciation for a translation.

Request URL: `https://t.song.work/api?text=你好&from=auto&to=en`
```json
{"statusCode":500,"error":"Internal Server Error","message":"Cannot read properties of null (reading 'innerText')"}
```

With my fix, it no longer errors when a pronunciation is not found, and the pronunciation keys are removed from the result.

Request URL: `http://localhost:8999/api?text=你好&from=auto&to=en`
```json
{"result":"Hello","from":{"pronunciation":"Nǐ hǎo"},"translations":{"interjection":[{"translation":"Hi!","reversedTranslations":["嗨!","你好!"],"frequency":"common"},{"translation":"Hallo!","reversedTranslations":["你好!"],"frequency":"rare"},{"translation":"Hello!","reversedTranslations":["你好!","喂!"],"frequency":"common"}]}}
```

I also updated the result `targetSelector` to fix missing translations that occur when there is no pronunciation.

closes https://github.com/Songkeys/Translateer/issues/22